### PR TITLE
Autotag: fix infinite loop with shellslash

### DIFF
--- a/vim/plugin/autotag.vim
+++ b/vim/plugin/autotag.vim
@@ -168,7 +168,7 @@ class AutoTag:
             open(tagsFile, 'wb').close()
             ret = (file, tagsFile)
             break
-         elif not file or file == os.sep or file == "/" or file == "\\":
+         elif not file or set(file).issubset(set((os.sep, "/", "\\"))):
             LOGGER.info('bail (file = "%s")' % (file, ))
             break
       return ret


### PR DESCRIPTION
This fixes a serious bug in autotag:

On windows, with shellslash enabled, autotag will hang vim in an infinite loop on every filesafe.
